### PR TITLE
Dynamo core annotations

### DIFF
--- a/extern/legacy_remove_me/readme.md
+++ b/extern/legacy_remove_me/readme.md
@@ -8,6 +8,7 @@ These files are actually empty .txt files renamed .dll to avoid including any du
 * \bin\Assimp64.dll,
 * \bin\AssimpNet.dll
 * \bin\Office.dll
+* \bin\Python.Runtime.NETStandard.dll
 * \bin\SharpDX.Direct3D11.Effects.dll
 * \bin\SharpDX.Toolkit.Compiler.dll
 * \bin\SharpDX.Toolkit.dll

--- a/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
@@ -135,8 +135,9 @@
     <member name="List.GroupByFunction">
       <summary>Use a function to determine how list items should be grouped.</summary>
       <param name="list">list of values</param>
-      <param name="function"></param>
-      <search>group,function</search>
+      <param name="groupFunction">Function to group list</param>
+      <returns name="groupedList">Grouped list</returns>
+      <search>group,function,groupbyfunction</search>
     </member>
     <member name="List.TrueForAll">
       <summary>Returns true if all items in the list evaluate to true with the given predicate.</summary>

--- a/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
+++ b/src/Engine/ProtoCore/ExtendedLibraries/BuiltIn.ds
@@ -12,9 +12,9 @@ class List extends DSCore.List
         return __Equals(objectA, objectB);
 	}
 
-	public static def GroupByFunction(list: var[]..[], func: Function)
+	public static def GroupByFunction(list: var[]..[], groupFunction: Function)
 	{
-		return __GroupByFunction(list, func);
+		return __GroupByFunction(list, groupFunction);
 	}
 
 	public static def SortByFunction(list: var[]..[], func: Function)

--- a/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
@@ -22,8 +22,8 @@ namespace CoreNodeModels.HigherOrder
 
         public ApplyFunction() : base()
         {
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("func", Resources.ApplyPortDataFuncToolTip)));
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("func(args)", Resources.ApplyPortDataFuncArgToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("function", Resources.ApplyPortDataFuncToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("result", Resources.ApplyPortDataFuncArgToolTip)));
             AddInput();
             RegisterAllPorts();
         }
@@ -31,9 +31,9 @@ namespace CoreNodeModels.HigherOrder
         protected override string GetInputName(int index)
         {
             if (index == 0)
-                return "func";
+                return "function";
 
-            return "arg" + index;
+            return "argument" + index;
         }
 
         protected override string GetInputTooltip(int index)

--- a/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
@@ -85,15 +85,15 @@ namespace CoreNodeModels.HigherOrder
 
         public ComposeFunctions()
         {
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("func0", Resources.ComposePortDataFunc0ToolTip)));
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("func1", Resources.ComposePortDataFunc1ToolTip)));
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("func", Resources.ComposePortDataResultToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("function0", Resources.ComposePortDataFunc0ToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("function1", Resources.ComposePortDataFunc1ToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("function", Resources.ComposePortDataResultToolTip)));
             RegisterAllPorts();
         }
 
         protected override string GetInputName(int index)
         {
-            return "func" + index;
+            return "function" + index;
         }
 
         protected override string GetInputTooltip(int index)

--- a/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/Apply.cs
@@ -33,7 +33,7 @@ namespace CoreNodeModels.HigherOrder
             if (index == 0)
                 return "function";
 
-            return "argument" + index;
+            return "argument" + (index-1);
         }
 
         protected override string GetInputTooltip(int index)
@@ -41,7 +41,7 @@ namespace CoreNodeModels.HigherOrder
             if (index == 0)
                 return "Function to apply.";
 
-            return "Argument #" + index;
+            return "Argument #" + (index-1);
         }
 
         protected override void RemoveInput()

--- a/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
@@ -57,11 +57,11 @@ namespace CoreNodeModels.HigherOrder
 
         protected CombinatorNode() : this(3)
         {
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("comb", Resources.CombinatorPortDataCombToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("combinator", Resources.CombinatorPortDataCombToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("list0", Resources.PortDataListToolTip + " #0")));
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("list1", Resources.PortDataListToolTip + " #1")));
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("list2", Resources.PortDataListToolTip + " #2")));
 
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("combined", Resources.CombinatorPortDataResultToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("list", Resources.CombinatorPortDataResultToolTip)));
 
             RegisterAllPorts();
         }
@@ -73,12 +73,12 @@ namespace CoreNodeModels.HigherOrder
 
         protected override string GetInputName(int index)
         {
-            return "list" + index;
+            return "list" + (index-1);
         }
 
         protected override string GetInputTooltip(int index)
         {
-            return Resources.PortDataListToolTip + " #" + index;
+            return Resources.PortDataListToolTip + " #" + (index-1);
         }
 
         protected override void RemoveInput()

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -530,7 +530,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to String representation of the object..
+        ///   Looks up a localized string similar to Result of math computation.
         /// </summary>
         public static string FormulaPortDataResultToolTip {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CoreNodeModels.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -530,7 +530,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Result of math computation.
+        ///   Looks up a localized string similar to String representation of the object..
         /// </summary>
         public static string FormulaPortDataResultToolTip {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -178,7 +178,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Combinator.
+        ///   Looks up a localized string similar to Function to use as combinator.
         /// </summary>
         public static string CombinatorPortDataCombToolTip {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -593,7 +593,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Applies a function to arguments..
+        ///   Looks up a localized string similar to Returns the result of a function with supplied arguments. Ex: arguments of a point and vector are applied to a translate function returning a translated point..
         /// </summary>
         public static string FunctionApplyDescription {
             get {
@@ -602,7 +602,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Compose multiple functions..
+        ///   Looks up a localized string similar to Returns a single function from multiple functions. Ex: the modulus and divide functions are composed into a single function to apply to a list..
         /// </summary>
         public static string FunctionComposeDescription {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -265,7 +265,7 @@
     <comment>Search tags. When do translation, appending localized tags to the existing tags and use ';' to seperate them</comment>
   </data>
   <data name="FunctionApplyDescription" xml:space="preserve">
-    <value>Applies a function to arguments.</value>
+    <value>Returns the result of a function with supplied arguments. Ex: arguments of a point and vector are applied to a translate function returning a translated point.</value>
     <comment>Description for Function.Apply</comment>
   </data>
   <data name="FunctionComposeDescription" xml:space="preserve">

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -152,7 +152,7 @@
     <value>A list of values between 0.0 and 1.0. These values are used to look up the color within the range.</value>
   </data>
   <data name="CombinatorPortDataCombToolTip" xml:space="preserve">
-    <value>Combinator</value>
+    <value>Function to use as combinator</value>
   </data>
   <data name="CombinatorPortDataResultToolTip" xml:space="preserve">
     <value>Combined lists</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -242,7 +242,7 @@
     <comment>Description for Formula</comment>
   </data>
   <data name="FormulaPortDataResultToolTip" xml:space="preserve">
-    <value>String representation of the object.</value>
+    <value>Result of math computation</value>
   </data>
   <data name="FromArrayPortDataArrayToolTip" xml:space="preserve">
     <value>The array of object to be serialized</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -242,7 +242,7 @@
     <comment>Description for Formula</comment>
   </data>
   <data name="FormulaPortDataResultToolTip" xml:space="preserve">
-    <value>Result of math computation</value>
+    <value>String representation of the object.</value>
   </data>
   <data name="FromArrayPortDataArrayToolTip" xml:space="preserve">
     <value>The array of object to be serialized</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -269,7 +269,7 @@
     <comment>Description for Function.Apply</comment>
   </data>
   <data name="FunctionComposeDescription" xml:space="preserve">
-    <value>Compose multiple functions.</value>
+    <value>Returns a single function from multiple functions. Ex: the modulus and divide functions are composed into a single function to apply to a list.</value>
     <comment>Description for Function.Compose</comment>
   </data>
   <data name="IfDescription" xml:space="preserve">

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -265,11 +265,11 @@
     <comment>Search tags. When do translation, appending localized tags to the existing tags and use ';' to seperate them</comment>
   </data>
   <data name="FunctionApplyDescription" xml:space="preserve">
-    <value>Applies a function to arguments.</value>
+    <value>Returns the result of a function with supplied arguments. Ex: arguments of a point and vector are applied to a translate function returning a translated point.</value>
     <comment>Description for Function.Apply</comment>
   </data>
   <data name="FunctionComposeDescription" xml:space="preserve">
-    <value>Compose multiple functions.</value>
+    <value>Returns a single function from multiple functions. Ex: the modulus and divide functions are composed into a single function to apply to a list.</value>
     <comment>Description for Function.Compose</comment>
   </data>
   <data name="IfDescription" xml:space="preserve">

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -152,7 +152,7 @@
     <value>A list of values between 0.0 and 1.0. These values are used to look up the color within the range.</value>
   </data>
   <data name="CombinatorPortDataCombToolTip" xml:space="preserve">
-    <value>Combinator</value>
+    <value>Function to use as combinator</value>
   </data>
   <data name="CombinatorPortDataResultToolTip" xml:space="preserve">
     <value>Combined lists</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -242,7 +242,7 @@
     <comment>Description for Formula</comment>
   </data>
   <data name="FormulaPortDataResultToolTip" xml:space="preserve">
-    <value>String representation of the object.</value>
+    <value>Result of math computation</value>
   </data>
   <data name="FromArrayPortDataArrayToolTip" xml:space="preserve">
     <value>The array of object to be serialized</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -242,7 +242,7 @@
     <comment>Description for Formula</comment>
   </data>
   <data name="FormulaPortDataResultToolTip" xml:space="preserve">
-    <value>Result of math computation</value>
+    <value>String representation of the object.</value>
   </data>
   <data name="FromArrayPortDataArrayToolTip" xml:space="preserve">
     <value>The array of object to be serialized</value>

--- a/src/Libraries/CoreNodeModels/String.cs
+++ b/src/Libraries/CoreNodeModels/String.cs
@@ -103,8 +103,8 @@ namespace CoreNodeModels
         public FromArray() : base("__ToStringFromArray")
         {
             ArgumentLacing = LacingStrategy.Disabled;
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("arr", Resources.FromArrayPortDataArrayToolTip)));
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("str", Resources.FromArrayPortDataResultToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("array", Resources.FromArrayPortDataArrayToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("string", Resources.FromArrayPortDataResultToolTip)));
             RegisterAllPorts();
         }
     }

--- a/src/Libraries/CoreNodeModels/String.cs
+++ b/src/Libraries/CoreNodeModels/String.cs
@@ -78,8 +78,8 @@ namespace CoreNodeModels
         public FromObject() : base("__ToStringFromObject")
         {
             ArgumentLacing = LacingStrategy.Disabled;
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("obj", Resources.FromObjectPortDataObjToolTip)));
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("str", Resources.FormulaPortDataResultToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("object", Resources.FromObjectPortDataObjToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("string", Resources.FormulaPortDataResultToolTip)));
             RegisterAllPorts();
         }
     }

--- a/src/Libraries/CoreNodeModels/String.cs
+++ b/src/Libraries/CoreNodeModels/String.cs
@@ -79,7 +79,7 @@ namespace CoreNodeModels
         {
             ArgumentLacing = LacingStrategy.Disabled;
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("object", Resources.FromObjectPortDataObjToolTip)));
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("string", Resources.FormulaPortDataResultToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("string", Resources.FromObjectPortDataResultToolTip)));
             RegisterAllPorts();
         }
     }


### PR DESCRIPTION
### Purpose
![image](https://user-images.githubusercontent.com/25138291/92587975-4b413b00-f290-11ea-91c4-aeccf4acecb7.png)

**1)  NODE:  String from Object**
-CHANGES: Rename str to string, obj to object, Output description: String representation of the object.

**2)  NODE:   String from Array**
-CHANGES: Rename str to string, arr to array

**3) NODE:  Output**
-Autodesk will take care of making this node not appear on library

**4) NODE: Function Apply**
-CHANGES: Rename func to function, arg1 to argument0 func(args) to result,
Description: Returns the result of a function with supplied arguments. Ex: arguments of a point and vector are applied to a translate function returning a translated point.

**5)  NODE: CoordinateSystem.ByMatrix**
-Autodesk will deprecate this node.

**6)  NODE:  Function Compose**
-CHANGES: Rename func0 to function0, fun to function
Description: Returns a single function from multiple functions. Ex: the modulus and divide functions are composed into a single function to apply to a list.

**7) NODE: Function Compose**
-CHANGES: Rename func0 to function0, fun to function
Description: Returns a single function from multiple functions. Ex: the modulus and divide functions are composed into a single function to apply to a list.

**8) NODE: List.LaceShortest**
-CHANGES: Rename comb to combinator, list1 to list0, combined to list
Input Description: function to use as combinator

**9) NODE: List.LaceLongest**
-CHANGES: Rename comb to combinator, list1 to list0, combined to list
Input Description: function to use as combinator 

**10) NODE: List.Combine**
-CHANGES: Rename comb to combinator, list1 to list0, combined to list
Input Description: function to use as combinator

**11) NODE: List.CartesianProduct (changed automatically by addressing nodes 8-10)**
-CHANGES: Rename comb to combinator, list1 to list0, combined to list
Input Description: function to use as combinator

### Reviewers
@SHKnudsen
@StudioLE
@MarkThorley
@anrova

### FYIs
-Autodesk should take care of making node Output not appear on library search and deprecate CoordinateSystem.ByMatrix
-Sol confirmed not renaming nodes that do not have DS syntax and starting all lists with 0 indexes.
-String from Object output was fixed to use appropriate tooltip