### PR TITLE
Node consistency 11 20

### DIFF
--- a/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
@@ -70,6 +70,7 @@
       <summary>Returns the items from the list that generate the minimum values for the function supplied as the key projector</summary>
       <param name="list">list of values</param>
       <param name="keyProjector">function applied to the list items</param>
+      <returns name="minItem">minimum item in list using keyProjector</returns>
       <search>min,item,key</search>
     </member>
     <member name="List.MaximumItemByKey">

--- a/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
@@ -70,7 +70,7 @@
       <summary>Returns the items from the list that generate the minimum values for the function supplied as the key projector</summary>
       <param name="list">list of values</param>
       <param name="keyProjector">function applied to the list items</param>
-      <returns name="minItem">minimum item in list using keyProjector</returns>
+      <returns name="minimumItem">minimum item in list using keyProjector</returns>
       <search>min,item,key</search>
     </member>
     <member name="List.MaximumItemByKey">

--- a/src/DynamoCore/BuiltInAndOperators/Operators.xml
+++ b/src/DynamoCore/BuiltInAndOperators/Operators.xml
@@ -110,9 +110,9 @@
         </member>
 		<member name="%Not">
 		            <summary>
-                !x
+                Reverses the result, returns false if the result is true
             </summary>
-            <param name="x">x value.</param>
+            <param name="x">boolean to reverse.</param>
             <search>not</search>
         </member>
     </members>

--- a/src/DynamoCore/BuiltInAndOperators/Operators.xml
+++ b/src/DynamoCore/BuiltInAndOperators/Operators.xml
@@ -113,6 +113,7 @@
                 Reverses the result, returns false if the result is true
             </summary>
             <param name="x">boolean to reverse.</param>
+            <returns name="boolean">reversed boolean</returns>
             <search>not</search>
         </member>
     </members>

--- a/src/Libraries/CoreNodeModels/Logic/AndOr.cs
+++ b/src/Libraries/CoreNodeModels/Logic/AndOr.cs
@@ -31,9 +31,9 @@ namespace CoreNodeModels.Logic
         {
             _op = op;
 
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("bool0", Resources.PortDataOperandToolTip)));
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("bool1", Resources.PortDataOperandToolTip)));
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("", Resources.PortDataResultToolTip)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("boolean0", Resources.PortDataOperandToolTip + 0)));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("boolean1", Resources.PortDataOperandToolTip + 1)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("boolean", Resources.PortDataResultToolTip)));
             RegisterAllPorts();
         }
 
@@ -60,7 +60,7 @@ namespace CoreNodeModels.Logic
 
         protected override string GetInputName(int index)
         {
-            return "bool" + index;
+            return "boolean" + index;
         }
 
         protected override string GetInputTooltip(int index)

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CoreNodeModels.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1349,7 +1349,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The result of the web request..
+        ///   Looks up a localized string similar to Content of a webpage as a string..
         /// </summary>
         public static string WebRequestPortDataResultToolTip {
             get {
@@ -1358,7 +1358,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The url for the web request..
+        ///   Looks up a localized string similar to The url for the web request as a string..
         /// </summary>
         public static string WebRequestPortDataUrlToolTip {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -494,7 +494,7 @@
     <comment>Description for Web Request</comment>
   </data>
   <data name="WebRequestPortDataResultToolTip" xml:space="preserve">
-    <value>Content of a webpage as a string.</value>
+    <value>Content of a web request as a string.</value>
   </data>
   <data name="WebRequestPortDataUrlToolTip" xml:space="preserve">
     <value>The url for the web request as a string.</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -494,10 +494,10 @@
     <comment>Description for Web Request</comment>
   </data>
   <data name="WebRequestPortDataResultToolTip" xml:space="preserve">
-    <value>The result of the web request.</value>
+    <value>Content of a webpage as a string.</value>
   </data>
   <data name="WebRequestPortDataUrlToolTip" xml:space="preserve">
-    <value>The url for the web request.</value>
+    <value>The url for the web request as a string.</value>
   </data>
   <data name="WatchNodeSearchTags" xml:space="preserve">
     <value>print;output;disply;panel;inspect;debug</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -394,7 +394,7 @@
     <value>List</value>
   </data>
   <data name="PortDataOperandToolTip" xml:space="preserve">
-    <value>operand</value>
+    <value>Boolean #</value>
   </data>
   <data name="PortDataResultToolTip" xml:space="preserve">
     <value>result</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -494,7 +494,7 @@
     <comment>Description for Web Request</comment>
   </data>
   <data name="WebRequestPortDataResultToolTip" xml:space="preserve">
-    <value>Content of a webpage as a string.</value>
+    <value>Content of a web request as a string.</value>
   </data>
   <data name="WebRequestPortDataUrlToolTip" xml:space="preserve">
     <value>The url for the web request as a string.</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -494,10 +494,10 @@
     <comment>Description for Web Request</comment>
   </data>
   <data name="WebRequestPortDataResultToolTip" xml:space="preserve">
-    <value>The result of the web request.</value>
+    <value>Content of a webpage as a string.</value>
   </data>
   <data name="WebRequestPortDataUrlToolTip" xml:space="preserve">
-    <value>The url for the web request.</value>
+    <value>The url for the web request as a string.</value>
   </data>
   <data name="WatchNodeSearchTags" xml:space="preserve">
     <value>print;output;disply;panel;inspect;debug</value>

--- a/src/Libraries/CoreNodeModels/WebRequest.cs
+++ b/src/Libraries/CoreNodeModels/WebRequest.cs
@@ -25,7 +25,7 @@ namespace CoreNodeModels
         public WebRequest()
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("url", Resources.WebRequestPortDataUrlToolTip)));
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("result", Resources.WebRequestPortDataResultToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("string", Resources.WebRequestPortDataResultToolTip)));
             RegisterAllPorts();
 
             CanUpdatePeriodically = true;

--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -107,10 +107,10 @@ namespace DSCore
         /// <summary>
         /// Returns the saturation value for this color.
         /// </summary>
-        /// <returns name="saturation">double between 0 and 1 inclusive.</returns>
-        public static float Saturation(Color c)
+        /// <returns name="double">Saturation value as double between 0 and 1 inclusive.</returns>
+        public static float Saturation(Color color)
         {
-            return c.color.GetSaturation();
+            return color.color.GetSaturation();
         }
 
         /// <summary>

--- a/src/Libraries/CoreNodes/Thread.cs
+++ b/src/Libraries/CoreNodes/Thread.cs
@@ -8,15 +8,15 @@
         /// <summary>
         ///     Pauses the current evaluation thread for a given amount of time.
         /// </summary>
-        /// <param name="x">Object to pass through.</param>
+        /// <param name="object">Object to pass through.</param>
         /// <param name="msTimeout">
         ///     Amount of time to pause the thread, in milliseconds.
         /// </param>
-        /// <returns name="x">Object passed through.</returns>
-        public static object Pause(object x, int msTimeout)
+        /// <returns name="object">Object passed through.</returns>
+        public static object Pause(object @object, int msTimeout)
         {
             System.Threading.Thread.Sleep(msTimeout);
-            return x;
+            return @object;
         }
     }
 }


### PR DESCRIPTION
### Purpose
The following PR addresses nodes' names and descriptions to make them more descriptive for beginners.

**12) NODE: Web Request**
-CHANGES: Output result to string. Input Description: The url for the web request as a string., Output Description: Content of a webpage as a string.

**13) NODE: CoordinateSystem.Rotate(coordinateSystem,plane,drees)**
-FYI: Node’s description is inside Protogeometry.dll should be changed by Autodesk

**14) NODE: Color.Saturation**
-CHANGES: Output saturation to double. Output Description: Saturation value as double between 0 and 1 inclusive.

**15) NODE: Thread.Pause**
CHANGES:
-Rename x in input and output to object.

**16) NODE: Convert Between Units**
NO CHANGES

**17)  NODE: Not**
CHANGES: Description: Reverses the result, returns false if the result is true
Input Description: boolean to reverse
Output: x to boolean
Output Description: reversed boolean
-FYI: Input could not be changed from x to Boolean, Autodesk should change in not reference.

**18) NODE: Or**
CHANGES: Input: bool0 to boolean0 Output empty to boolean Description: boolean to reverse
Input Description operand to Boolean #0...

**19) NODE: And**
CHANGES: Input: bool0 to boolean0 Output empty to boolean Description: boolean to reverse
Input Description operand to Boolean #0...

**20) NODE: List.MinimumItemByKey**
Output: minimumItem
Output Description: minimum item in list using keyProjector

![image](https://user-images.githubusercontent.com/25138291/92714870-a8062980-f354-11ea-9dda-c05348084136.png)

### Reviewers
@SHKnudsen
@StudioLE
@MarkThorley
@anrova

### FYIs
-	Node CoordinateSystem.Rotate: Node’s description is inside Protogeometry.dll should be changed by Autodesk 
-	Node Not:  Input could not be changed from x to boolean, Autodesk should change in not reference.

