### PR TITLE
Node consistency 21 30

### DIFF
--- a/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
@@ -76,6 +76,7 @@
       <summary>Returns the items from the list that generate the maximum values for the function supplied as the key projector</summary>
       <param name="list">list of values</param>
       <param name="keyProjector">function applied to the list items</param>
+      <returns name="maxItem">maximum item in list using keyProjector</returns>
       <search>max,item,key</search>
     </member>
     <member name="__Replace">

--- a/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
+++ b/src/DynamoCore/BuiltInAndOperators/BuiltIn.xml
@@ -76,7 +76,7 @@
       <summary>Returns the items from the list that generate the maximum values for the function supplied as the key projector</summary>
       <param name="list">list of values</param>
       <param name="keyProjector">function applied to the list items</param>
-      <returns name="maxItem">maximum item in list using keyProjector</returns>
+      <returns name="maximumItem">maximum item in list using keyProjector</returns>
       <search>max,item,key</search>
     </member>
     <member name="__Replace">

--- a/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
@@ -283,9 +283,9 @@ namespace CoreNodeModels.HigherOrder
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("reductor", Resources.ReducePortDataReductorToolTip)));
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("seed", Resources.ReducePortDataSeedToolTip)));
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("list1", Resources.PortDataListToolTip + " #1")));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("list0", Resources.PortDataListToolTip + " #0")));
 
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("reduced", Resources.ReducePortDataResultToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("list", Resources.ReducePortDataResultToolTip)));
 
             RegisterAllPorts();
         }
@@ -325,12 +325,12 @@ namespace CoreNodeModels.HigherOrder
 
         protected override string GetInputName(int index)
         {
-            return "list" + index;
+            return "list" + (index-1);
         }
 
         protected override string GetInputTooltip(int index)
         {
-            return Resources.PortDataListToolTip + " #" + index;
+            return Resources.PortDataListToolTip + " #" + (index-1);
         }
 
         protected override int GetInputIndex()

--- a/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
+++ b/src/Libraries/CoreNodeModels/HigherOrder/MapCombineLacing.cs
@@ -373,9 +373,9 @@ namespace CoreNodeModels.HigherOrder
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("reductor", Resources.ScanPortDataReductorToolTip)));
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("seed", Resources.ScanPortDataSeedToolTip)));
-            InPorts.Add(new PortModel(PortType.Input, this, new PortData("list1", Resources.PortDataListToolTip + " #1")));
+            InPorts.Add(new PortModel(PortType.Input, this, new PortData("list0", Resources.PortDataListToolTip + " #0")));
 
-            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("scanned", Resources.ScanPortDataResultToolTip)));
+            OutPorts.Add(new PortModel(PortType.Output, this, new PortData("list", Resources.ScanPortDataResultToolTip)));
 
             RegisterAllPorts();
         }
@@ -415,12 +415,12 @@ namespace CoreNodeModels.HigherOrder
 
         protected override string GetInputName(int index)
         {
-            return "list" + index;
+            return "list" + (index-1);
         }
 
         protected override string GetInputTooltip(int index)
         {
-            return "List" + index;
+            return "List #" + (index-1);
         }
 
         protected override int GetInputIndex()

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -422,7 +422,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Creates a file object from a path. A file object loads the selected file in memory for use downstream..
+        ///   Looks up a localized string similar to Creates a file object from a path..
         /// </summary>
         public static string FileFromPathDescription {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CoreNodeModels.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -422,7 +422,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Creates a file object from a path..
+        ///   Looks up a localized string similar to Creates a file object from a path. A file object loads the selected file in memory for use downstream..
         /// </summary>
         public static string FileFromPathDescription {
             get {
@@ -449,7 +449,7 @@ namespace CoreNodeModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path to the file..
+        ///   Looks up a localized string similar to Path to the file as string..
         /// </summary>
         public static string FileObjectPortDataPathToolTip {
             get {

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -206,7 +206,7 @@
     <value>The selected {0}</value>
   </data>
   <data name="FileFromPathDescription" xml:space="preserve">
-    <value>Creates a file object from a path.</value>
+    <value>Creates a file object from a path. A file object loads the selected file in memory for use downstream.</value>
     <comment>Description for File.FromPath</comment>
   </data>
   <data name="FilenameNodeDescription" xml:space="preserve">
@@ -216,7 +216,7 @@
     <value>Creates a file object from a path.</value>
   </data>
   <data name="FileObjectPortDataPathToolTip" xml:space="preserve">
-    <value>Path to the file.</value>
+    <value>Path to the file as string.</value>
   </data>
   <data name="FileObjectPortDataResultToolTip" xml:space="preserve">
     <value>File object</value>

--- a/src/Libraries/CoreNodeModels/Properties/Resources.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.resx
@@ -206,7 +206,7 @@
     <value>The selected {0}</value>
   </data>
   <data name="FileFromPathDescription" xml:space="preserve">
-    <value>Creates a file object from a path. A file object loads the selected file in memory for use downstream.</value>
+    <value>Creates a file object from a path.</value>
     <comment>Description for File.FromPath</comment>
   </data>
   <data name="FilenameNodeDescription" xml:space="preserve">

--- a/src/Libraries/CoreNodes/List.cs
+++ b/src/Libraries/CoreNodes/List.cs
@@ -1217,7 +1217,7 @@ namespace DSCore
         /// </summary>
         /// <param name="list">List to permute.</param>
         /// <param name="length">Length of each permutation.</param>
-        /// <returns name="perm">Permutations of the list of the given length.</returns>
+        /// <returns name="permutations">Permutations of the list of the given length.</returns>
         /// <search>permutation,permutations</search>
         [IsVisibleInDynamoLibrary(true)]
         public static IList Permutations(IList list, int? length = null)


### PR DESCRIPTION
### Purpose

The following PR addresses nodes' names and descriptions to make them more descriptive for beginners.

**21) NODE: List.MaximumItemByKey**
Output: maximumItem
Output Description: maximum item in list using keyProjector

**22) NODE:  List.Scan**
-CHANGES: 
Output: scanned to list
Inputs: list1 to list0
Input Description: list1 to List #0

**23) NODE:  List.Reduce**
-CHANGES: 
Output: reduced to list
Inputs: list1 to list0
Input Description: list1 to List #0

**24) NODE:  List.Permutations**
-CHANGES: 
Output: perm to permutations
CHECKED:
its working in Automatic lacing

**25) NODE:  List.Create**
-CHANGES: No changes needed

**26) NODE:  File From Path**
-CHANGES: 
Input description: Path to the file as string,

**27) NODE:  Geometry.ToSolidDef** 
-FYI: Node’s description is inside Protogeometry.dll should be changed by Autodesk

**28) NODE:  Curve.Length**
-FYI: Node’s description is inside Protogeometry.dll should be changed by Autodesk

**29) NODE:  Curve.IsPlanar**
-FYI: Node’s description is inside Protogeometry.dll should be changed by Autodesk

**30) NODE:  Curve.IsClosed**
-FYI: Node’s description is inside Protogeometry.dll should be changed by Autodesk

![image](https://user-images.githubusercontent.com/25138291/92719376-f1597780-f35a-11ea-8df9-96ed8ea5b6d3.png)


### Reviewers
@SHKnudsen
@StudioLE
@MarkThorley
@anrova

### FYIs
-	Geometry.ToSolidDef, Curve.Length, Curve.IsPlanar, Curve.IsClosed  : Node is inside Protogeometry.dll should be changed by Autodesk 

