### PR TITLE
Node consistency 31 40

### DIFF
--- a/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
+++ b/src/Libraries/CoreNodeModels/Properties/Resources.en-US.resx
@@ -388,7 +388,7 @@
     <value>False block</value>
   </data>
   <data name="PortDataImageToolTip" xml:space="preserve">
-    <value>image</value>
+    <value>Image for visualization</value>
   </data>
   <data name="PortDataListToolTip" xml:space="preserve">
     <value>List</value>

--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -19,7 +19,7 @@ namespace DSCore
         /// <summary>
         ///     Find the red component of a color, 0 to 255.
         /// </summary>
-        /// <returns name="red">int between 0 and 255 inclusive.</returns>
+        /// <returns name="red">Red value for RGB color model, int between 0 and 255 inclusive.</returns>
         [JsonProperty(PropertyName = "R")]
         public byte Red
         {

--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -19,7 +19,7 @@ namespace DSCore
         /// <summary>
         ///     Find the red component of a color, 0 to 255.
         /// </summary>
-        /// <returns name="int">Red value for RGB color model, int between 0 and 255 inclusive.</returns>
+        /// <returns name="integer">Red value for RGB color model, int between 0 and 255 inclusive.</returns>
         [JsonProperty(PropertyName = "R")]
         public byte Red
         {

--- a/src/Libraries/CoreNodes/Color.cs
+++ b/src/Libraries/CoreNodes/Color.cs
@@ -19,7 +19,7 @@ namespace DSCore
         /// <summary>
         ///     Find the red component of a color, 0 to 255.
         /// </summary>
-        /// <returns name="red">Red value for RGB color model, int between 0 and 255 inclusive.</returns>
+        /// <returns name="int">Red value for RGB color model, int between 0 and 255 inclusive.</returns>
         [JsonProperty(PropertyName = "R")]
         public byte Red
         {


### PR DESCRIPTION
### Purpose

The following PR addresses nodes' names and descriptions to make them more descriptive for beginners.

**31) NODE:  Vector.Dot**
-FYI: is inside Protogeometry.dll should be changed by Autodesk CHANGE SUGGESTED: i/o naming and descriptions

**32) NODE:  CoordinateSystem.Transform**
-FYI: is inside Protogeometry.dll should be changed by Autodesk  CHANGE SUGGESTED: Seems to not function at all?

**33) NODE:  CoordinateSystem.Scale1D**
-FYI: is inside Protogeometry.dll should be changed by Autodesk  CHANGE SUGGESTED:  Description needs work

**34) NODE:  CoordinateSystem.Mirror**
-CHANGES: No changes

**35) NODE:  CoordinateSystem.IsEqualTo**
-FYI: is inside Protogeometry.dll should be changed by Autodesk  CHANGE SUGGESTED: Revise input name, add descriptions

**36) NODE:  BoundingBox.IsEmpty**
-FYI: is inside Protogeometry.dll should be changed by Autodesk  CHANGE SUGGESTEDI am not too sure how to get this to return "TRUE". Node is odd.

**37) NODE:  BoundingBox.Intersects**
-FYI: is inside Protogeometry.dll should be changed by Autodesk  CHANGE SUGGESTED: Input/Output cleanup for name and decription.

**38) NODE: Watch Image**
-CHANGES: 
Description: Input Description: Image for visualization

**39) NODE: Watch 3D**
-CHANGES: No changes

**40) NODE: Color Red**
-CHANGES: 
Output= red to int.
Description: Output Description: Red value for RGB color model, int between 0 and 255 inclusive.

![image](https://user-images.githubusercontent.com/25138291/92726063-f3283880-f364-11ea-9aa5-cc2a64c73425.png)


### Reviewers
@SHKnudsen
@StudioLE
@MarkThorley
@anrova

### FYIs
-	Nodes 31-33, 35-37: inside Protogeometry.dll should be changed by Autodesk.
